### PR TITLE
Use api library from google instead of cached dowloaded file.

### DIFF
--- a/google_attachment/views/assets.xml
+++ b/google_attachment/views/assets.xml
@@ -3,7 +3,7 @@
 
     <template id="assets_backend" name="google_attachment assets_backend" inherit_id="web.assets_backend">
         <xpath expr="." position="inside">
-            <script type="text/javascript" src="/google_attachment/static/lib/gapi.js"></script>
+            <script type="text/javascript" src="https://apis.google.com/js/api.js"></script>
             <script type="text/javascript" src="/google_attachment/static/src/js/GoogleOAuthAuthenticator.js"></script>
             <script type="text/javascript" src="/google_attachment/static/src/js/GooglePickerManager.js"></script>
             <script type="text/javascript" src="/google_attachment/static/src/js/Sidebar.js"></script>


### PR DESCRIPTION
The dowloaded version of the file becomes deprecated after a certain time.
Google advises to use the file from the url https://apis.google.com/js/api.js.

https://github.com/google/google-api-javascript-client/issues/206

https://isidor.numigi.net/web#id=4526&view_type=form&model=project.task&action=298&menu_id=200