### PR TITLE
Convert domain to string when saving user dashboard

### DIFF
--- a/web_contextual_search_favorite/static/src/js/dashboard.js
+++ b/web_contextual_search_favorite/static/src/js/dashboard.js
@@ -1,0 +1,30 @@
+odoo.define("web_contextual_search_favorite.dashboard", function (require) {
+"use strict";
+
+
+var BoardView = require("board.BoardView");
+
+BoardView.prototype.config.Renderer.include({
+    /**
+     * Stringify the domain when generating the architecture or the board.
+     *
+     * Without this method, the domain is passed as a javascript object to QWeb
+     * and is not rendered properly.
+     *
+     * In the source code of Odoo, the same logic is applied to modifiers.
+     * See method getBoard in odoo/addons/board/static/src/js/board_view.js.
+     */
+    getBoard: function () {
+        var result = this._super.apply(this, arguments);
+        result.columns.forEach((column) => {
+            column.forEach((action) => {
+                if(action.domain){
+                    action.domain = JSON.stringify(action.domain);
+                }
+            });
+        });
+        return result;
+    },
+});
+
+});

--- a/web_contextual_search_favorite/static/src/js/dashboard.js
+++ b/web_contextual_search_favorite/static/src/js/dashboard.js
@@ -14,7 +14,7 @@ BoardView.prototype.config.Renderer.include({
      * In the source code of Odoo, the same logic is applied to modifiers.
      * See method getBoard in odoo/addons/board/static/src/js/board_view.js.
      */
-    getBoard: function () {
+    getBoard() {
         var result = this._super.apply(this, arguments);
         result.columns.forEach((column) => {
             column.forEach((action) => {

--- a/web_contextual_search_favorite/views/assets.xml
+++ b/web_contextual_search_favorite/views/assets.xml
@@ -6,6 +6,7 @@
             <script type="text/javascript" src="/web_contextual_search_favorite/static/dist/webContextualSearchFavorite.js"></script>
             <script type="text/javascript" src="/web_contextual_search_favorite/static/src/js/FavoriteMenu.js"></script>
             <script type="text/javascript" src="/web_contextual_search_favorite/static/src/js/pyeval.js"></script>
+            <script type="text/javascript" src="/web_contextual_search_favorite/static/src/js/dashboard.js"></script>
         </xpath>
     </template>
 


### PR DESCRIPTION
This commit fixes an issue where the dashboard would be broken when the user removed a section through the web interface.

The domain would be wrongly interpreted when generating the new view using QWeb.
The solution is to deal with the domain the same way it is dealt with modifiers (attrs).

https://isidor.numigi.net/web#id=14718&model=project.task&view_type=form&menu_id=200