### PR TITLE
Prevent triggering the record removal

### DIFF
--- a/web_trash_condition/static/src/js/trash.js
+++ b/web_trash_condition/static/src/js/trash.js
@@ -28,6 +28,7 @@ require("web.ListRenderer").include({
 
     _hideTrashFromRow($row) {
         $row.find('.o_list_record_remove button').addClass("d-none");
+        $row.find('.o_list_record_remove').removeClass("o_list_record_remove");
     },
 });
 });


### PR DESCRIPTION
The event to remove the record was not triggered by the trash icon.
It is triggered by the parent div (.o_list_record_remove).
Therefore, the parent div must be hidden as well.