### PR TITLE
Force google oauth if scope not granted

### DIFF
--- a/google_attachment/static/src/js/GoogleOAuthAuthenticator.js
+++ b/google_attachment/static/src/js/GoogleOAuthAuthenticator.js
@@ -16,6 +16,7 @@ var GoogleOAuthAuthenticator = Class.extend({
         this._clientId = clientId;
         this._googleAuth = null;
         this._apiLoaded = false;
+        this._scope = scope
         this._signInOptions = {
             scope,
             prompt: "select_account",
@@ -28,13 +29,13 @@ var GoogleOAuthAuthenticator = Class.extend({
      * @returns {$.Deferred} a deferred that resolves when the user is authentified.
      */
     authenticate() {
-        var self = this;
-        var deferred = new $.Deferred();
+        const self = this;
+        const deferred = new $.Deferred();
 
         this._loadApi().then(function(){
             self._googleAuth = gapi.auth2.init({client_id: self._clientId});
             self._googleAuth.then(function(){
-                if(self._googleAuth.isSignedIn.get()){
+                if(self._isSignedIn()){
                     deferred.resolve();
                 }
                 else{
@@ -49,20 +50,28 @@ var GoogleOAuthAuthenticator = Class.extend({
         return deferred;
     },
 
+    getToken(){
+        const user = this._getOauthUser()
+        const data = user.getAuthResponse(true)
+        return data.access_token;
+    },
 
-    /**
-     * Load the google oauth2 api.
-     *
-     * @returns {$.Deferred} a deferred that resolves when the api is loaded.
-     */
+    _isSignedIn() {
+        if (!this._googleAuth.isSignedIn.get()) {
+            return false
+        }
+        const user = this._getOauthUser()
+        return user.hasGrantedScopes(this._scope)
+    },
+
     _loadApi(){
-        var deferred = new $.Deferred();
+        const deferred = new $.Deferred();
 
         if(this._apiLoaded){
             deferred.resolve();
         }
         else {
-            var self = this;
+            const self = this;
             gapi.load("auth2", function(){
                 self._apiLoaded = true;
                 deferred.resolve();
@@ -72,14 +81,8 @@ var GoogleOAuthAuthenticator = Class.extend({
         return deferred;
     },
 
-    /**
-     * Get the user's oauth token.
-     *
-     * @returns {String} the token
-     */
-    getToken(){
-        var user = this._googleAuth.currentUser.get();
-        return user.getAuthResponse(true).access_token;
+    _getOauthUser() {
+        return this._googleAuth.currentUser.get();
     },
 });
 


### PR DESCRIPTION
Force the user to authentify if the current access token has
not the required scope to access google drive.

This case happens when the user logged into Odoo using google oauth.

The user has an access token, but not for the correct scope.